### PR TITLE
Handle adding other parties to the case

### DIFF
--- a/efile_app/efile/api/dropdown_views.py
+++ b/efile_app/efile/api/dropdown_views.py
@@ -616,6 +616,7 @@ class DropdownAPIViews(APIResponseMixin):
             court_code = request.GET.get("court")
             case_type_code = request.GET.get("case_type")
             jurisdiction = request.GET.get("jurisdiction")
+            only_required = request.GET.get("only_required", "True").lower() == "true"
 
             if not jurisdiction:
                 return DropdownAPIViews.error_response("Missing required jurisidiction parameter")
@@ -642,6 +643,9 @@ class DropdownAPIViews(APIResponseMixin):
                     for party_type in api_data:
                         if isinstance(party_type, dict) and "code" in party_type and "name" in party_type:
                             # Include all party types for now (no filtering)
+                            is_required = party_type.get("isrequired", False)
+                            if not is_required and only_required:
+                                continue
 
                             party_types.append(
                                 {
@@ -649,7 +653,7 @@ class DropdownAPIViews(APIResponseMixin):
                                     "text": party_type["name"],
                                     "code": party_type["code"],
                                     "name": party_type["name"],
-                                    "isRequired": party_type.get("isrequired", False),
+                                    "isRequired": is_required,
                                     "isAvailableForNewParties": party_type.get("isAvailableForNewParties", True),
                                 }
                             )
@@ -657,15 +661,7 @@ class DropdownAPIViews(APIResponseMixin):
                     # Sort alphabetically by name
                     party_types.sort(key=lambda x: x["name"])
 
-                return DropdownAPIViews.success_response(
-                    {
-                        "party_types": party_types,
-                        "count": len(party_types),
-                        "source": "suffolk_api",
-                        "court": court_code,
-                        "case_type": case_type_code,
-                    }
-                )
+                return DropdownAPIViews.success_response(party_types)
             else:
                 # Log the error but don't expose sensitive details
                 error_msg = f"External API returned status {response.status_code}"

--- a/efile_app/efile/api/suffolk_api_views.py
+++ b/efile_app/efile/api/suffolk_api_views.py
@@ -215,6 +215,7 @@ def get_party_types_from_suffolk_api(request):
         court = request.GET.get("court")
         case_type = request.GET.get("case_type")
         existing_case = request.GET.get("existing_case", "no")
+        only_required = request.GET.get("only_required", "False").lower() == "true"
 
         if not court or not case_type:
             return JsonResponse({"success": False, "error": "Court and case_type parameters are required"}, status=400)
@@ -303,8 +304,13 @@ def get_party_types_from_suffolk_api(request):
 
                 print(f"Saved party type to session: {selected_party_type}")
 
+                if only_required:
+                    filtered_party_types = [p for p in party_types if p.get("isrequired", False)]
+                else:
+                    filtered_party_types = party_types
+                logger.info("only_required: %s, filtered: %s", only_required, filtered_party_types)
                 return JsonResponse(
-                    {"success": True, "party_types": party_types, "selected_party_type": selected_party_type}
+                    {"success": True, "party_types": filtered_party_types, "selected_party_type": selected_party_type}
                 )
             else:
                 return JsonResponse({"success": False, "error": "No party types returned from Suffolk API"}, status=400)

--- a/efile_app/efile/static/config/base-case-types.yaml
+++ b/efile_app/efile/static/config/base-case-types.yaml
@@ -3,25 +3,83 @@
 
 # Global defaults that apply to all states unless overridden
 defaults:
-  field_types:
-    text:
-      class: "form-control"
-      validation: "required"
-    textarea:
-      class: "form-control"
-      rows: 3
-    number:
-      class: "form-control"
-      validation: "numeric"
-    party_type_dropdown:
-      class: "form-control dropdown-field"
-      validation: "required"
+  sections:
+    parties:
+      title: "Required Parties"
+      show if:
+        var: required_party_types.length
+        op: gt
+        rhs: 1
+      api_endpoint: "/api/dropdowns/party-types/"
+      requires_params: ["court", "case_type"]
+      fields:
+        - section_title: "The Other Side"
+          required: true
+          conditional_requirements:
+            # Default: show for all courts except those explicitly hidden
+          fields:
+            - name: "other_party_type"
+              label: "Party Type"
+              type: "party_type_dropdown"
+              required: true
+              column_width: "col-12"
+              api_endpoint: "/api/dropdowns/party-types/"
+            - name: "other_first_name"
+              label: "First Name"
+              type: "text"
+              required: true
+              column_width: "col-6"
+            - name: "other_last_name"
+              label: "Last Name"
+              type: "text"
+              required: true
+              column_width: "col-6"
+        - section_title: "Their Physical Address"
+          required: true
+          conditional_requirements:
+            # Default: show for all courts except those explicitly hidden
+          fields:
+            - name: "other_address_line_1"
+              label: "Street Address"
+              type: "text"
+              required: true
+              column_width: "col-12"
+            - name: "other_address_line_2"
+              label: "Street Address 2"
+              type: "text"
+              required: true
+              column_width: "col-12"
+            - name: "other_address_city"
+              label: "City"
+              type: "text"
+              required: true
+              column_width: "col-6"
+            - name: "other_address_state"
+              label: "State"
+              type: "us_state"
+              required: true
+              column_width: "col-6"
+            - name: "other_address_zip"
+              label: "Zip Code"
+              type: "text"
+              required: true
+              column_width: "col-6"
+        - section_title: "Their Contact Information"
+          required: true
+          conditional_requirements:
+            # Default: show for all courts except those explicitly hidden
+          fields:
+            - name: "other_email"
+              label: "Email"
+              type: "email"
+              required: true
+              column_width: "col-12"
+            - name: "other_phone_number"
+              label: "Phone number"
+              type: "tel"
+              required: true
+              column_width: "col-12"
 
-  column_widths:
-    full: "col-12"
-    half: "col-6"
-    third: "col-4"
-    two_thirds: "col-8"
 
 # Base case type templates that states can inherit from
 base_case_types:
@@ -34,30 +92,6 @@ base_case_types:
         api_endpoint: "/api/dropdowns/party-types/"
         requires_params: ["court", "case_type"]
         fields:
-          - section_title: "Petitioner"
-            required: true
-            conditional_requirements:
-              # Default: show for all courts except those explicitly hidden
-              required_for_courts: []
-              optional_for_courts: []
-              hidden_for_courts: []
-            fields:
-              - name: "petitioner_party_type"
-                label: "Party Type"
-                type: "party_type_dropdown"
-                required: true
-                column_width: "col-12"
-                api_endpoint: "/api/dropdowns/party-types/"
-              - name: "petitioner_first_name"
-                label: "First Name"
-                type: "text"
-                required: true
-                column_width: "col-6"
-              - name: "petitioner_last_name"
-                label: "Last Name"
-                type: "text"
-                required: true
-                column_width: "col-6"
           - section_title: "Name Sought"
             required: false
             conditional_requirements:

--- a/efile_app/efile/static/css/expert_form.css
+++ b/efile_app/efile/static/css/expert_form.css
@@ -180,3 +180,9 @@ option.recommended {
   padding-top: 1rem;
   border-top: 1px solid #e9ecef;
 }
+
+h4 {
+  margin-top: 2rem;
+  margin-bottom: 1rem !important;
+  color: #007bff;
+}

--- a/efile_app/efile/static/js/cascading-dropdowns.js
+++ b/efile_app/efile/static/js/cascading-dropdowns.js
@@ -14,9 +14,13 @@ class CascadingDropdowns {
         endpoint: "/api/dropdowns/case-types/",
       },
       case_type: {
-        next: null, // Case type is now the final dropdown on expert form
-        endpoint: null,
+        next: "party_type", // Case type is now the final dropdown on expert form
+        endpoint: "/api/dropdowns/party-types",
       },
+      party_type: {
+        next: null,
+        endpoint: null
+      }
     };
 
     this.userProfile = null;
@@ -24,6 +28,7 @@ class CascadingDropdowns {
       court: null,
       case_category: null,
       case_type: null,
+      party_type: null,
     };
     this.optionalServicesLoaded = false;
     this.isAutomaticSelection = false; // Track if selection is automatic
@@ -156,7 +161,12 @@ class CascadingDropdowns {
           response.data.length > 0
         ) {
           this.populateDropdown(dropdown, response.data);
+          dropdown.parentElement.removeAttribute("hidden");
           dropdown.disabled = false;
+          if (response.data.length == 1 && dropdown.id =="party_type") {
+            dropdown.parentElement.hidden = true;
+            dropdown.value = response.data[0].value || response.data[0].id;
+          }
         } else {
           console.warn(`No data returned for ${fieldId}:`, response);
           this.showError(dropdown, "No options available for this selection");
@@ -228,6 +238,7 @@ class CascadingDropdowns {
         }
       } else if (fieldId === "case_type") {
         params.parent = selectedValue; // Suffolk API expects parent parameter for case_type
+        params.case_type = selectedValue;
         if (this.selectedValues.court) {
           params.court = this.selectedValues.court;
         } else {
@@ -240,7 +251,7 @@ class CascadingDropdowns {
         const isInitialFiling = existingCase === 'no';
         params.existing_case = existingCase; // Pass existing_case to Django API
         params.initial = isInitialFiling ? 'true' : 'false'; // Pass initial to Suffolk API
-      }
+      } 
 
       // Validate required parameters before making API call
       if (this.validateParameters(fieldId, params)) {
@@ -248,6 +259,7 @@ class CascadingDropdowns {
         if (mapping.next && mapping.endpoint) {
           params.guessed_case_category = this.guesses['case category'];
           params.guessed_case_type = this.guesses['case type'];
+          params.only_required = true;
           this.loadDropdownData(mapping.next, mapping.endpoint, params);
         }
       } else {
@@ -651,7 +663,7 @@ class CascadingDropdowns {
     const dependencies = {
       court: ["case_category", "case_type"],
       case_category: ["case_type"],
-      case_type: [], // case_type is now the final dropdown on expert form
+      case_type: ["party_type"], // case_type is now the final dropdown on expert form
     };
 
     const toClear = dependencies[changedFieldId] || [];
@@ -876,6 +888,7 @@ class CascadingDropdowns {
       "court",
       "case_category",
       "case_type",
+      "party_type",
       "filing_type",
       "document_type",
     ];
@@ -959,17 +972,6 @@ class CascadingDropdowns {
     if (dropdown) {
       dropdown.disabled = false;
     }
-  }
-
-  /**
-   * Reload courts when jurisdiction changes
-   * Called when jurisdiction switch happens without page reload
-   */
-  async reloadCourtsForJurisdiction() {
-    this.clearAllDropdowns();
-
-    // Reload courts with new jurisdiction context
-    await this.loadCourtsWithUserContext();
   }
 
   /**

--- a/efile_app/efile/static/js/dynamic-form-sections.js
+++ b/efile_app/efile/static/js/dynamic-form-sections.js
@@ -12,7 +12,7 @@ class DynamicFormSections {
     this.preservedCaseType = null;
 
     this.jurisdiction = apiUtils.getCurrentJurisdiction();
-    //this.init();
+    this.init();
   }
 
   async init() {
@@ -137,9 +137,6 @@ class DynamicFormSections {
               result.data.case_type_name || "name_change"
             ] = caseConfig;
           }
-        } else {
-          // Also load the static base configuration to ensure we have eviction config
-          await this.loadStaticBaseConfiguration();
         }
       } else {
         console.error(
@@ -147,14 +144,16 @@ class DynamicFormSections {
           result.error || "Unknown error"
         );
         this.config = this.getDefaultConfig();
-        // Fallback: load static base configuration
-        await this.loadStaticBaseConfiguration();
+      }
+
+      let party_params = {"case_type": caseTypeValue, "jurisdiction": this.jurisdiction, "court": court, "existing_case": "no"};
+      const parties_result = await apiUtils.getPartyTypes(party_params);
+      if (parties_result.success && parties_result.party_types) {
+        this.parties = parties_result.party_types;
       }
     } catch (error) {
       console.error("Error loading configuration:", error);
       this.config = this.getDefaultConfig();
-      // Fallback: load static base configuration
-      await this.loadStaticBaseConfiguration();
     }
   }
 
@@ -169,22 +168,6 @@ class DynamicFormSections {
       return ["name change", "name petition", "change of name"];
     }
     return [caseTypeName.toLowerCase()];
-  }
-
-  // Load static base configuration as fallback
-  async loadStaticBaseConfiguration() {
-    try {
-      // Try to load the static base-case-types.yaml configuration
-      const response = await fetch("/static/config/base-case-types.yaml");
-      if (response.ok) {
-        const yamlText = await response.text();
-        // This is a simplified YAML parser - in production you'd want a proper YAML library
-        // For now, just ensure we have the base case types available
-        this.config.base_case_types = this.config.base_case_types || {};
-      }
-    } catch (error) {
-      console.warn("Could not load static base configuration:", error);
-    }
   }
 
   async loadExistingCaseData() {
@@ -293,10 +276,10 @@ class DynamicFormSections {
 
     if (caseTypeConfig) {
       this.currentCaseType = caseTypeValue; // Track the current case type
-      //this.renderCaseTypeForm(caseTypeConfig);
-      //this.showDynamicSections();
+      this.renderCaseTypeForm(caseTypeConfig);
+      this.showDynamicSections();
     } else {
-      //this.hideDynamicSections();
+      this.hideDynamicSections();
     }
   }
 
@@ -403,24 +386,24 @@ class DynamicFormSections {
 
     // Render case information section (should come first)
     if (sections.case_information) {
-      this.renderSection("case_information", sections.case_information);
+      this.renderSection("case_information", sections.case_information || {});
     }
 
     // Render parties section
     if (sections.parties) {
-      this.renderSection("parties", sections.parties);
+      this.renderSection("parties", sections.parties || {});
     }
 
     // Render services section
     if (sections.services) {
-      this.renderSection("services", sections.services);
+      this.renderSection("services", sections.services || {});
     }
 
     // Restore preserved state after rendering
     this.restorePreservedState();
 
     // Load party type dropdowns after all sections are rendered
-    //this.loadPartyTypeDropdowns();
+    this.loadPartyTypeDropdowns();
 
     // Update form validation after rendering
     this.updateFormValidation();
@@ -580,6 +563,13 @@ class DynamicFormSections {
     const fields = sectionConfig.fields || [];
     let html = "";
 
+    let party_types = this.parties;
+
+    if (party_types.length <= 1) {
+      // Skip rendering
+      return "";
+    }
+
     fields.forEach((partyGroup) => {
       if (partyGroup.section_title) {
         // Check if this section should be shown based on current court selection
@@ -587,7 +577,7 @@ class DynamicFormSections {
 
         // Skip rendering this section entirely if it shouldn't be shown
         if (!shouldShow) {
-          return;
+          return "";
         }
 
         // Check if this section should be required based on current court selection
@@ -841,6 +831,73 @@ class DynamicFormSections {
         inputHtml = `<input type="tel" class="form-control" id="${fieldId}" name="${fieldName}" ${requiredAttr}>`;
         break;
 
+      case "us_state":
+        const STATE_CHOICES = [
+        ["", "Select a state"],
+        ["AL", "Alabama"],
+        ["AK", "Alaska"],
+        ["AS", "American Samoa"],
+        ["AZ", "Arizona"],
+        ["AR", "Arkansas"],
+        ["CA", "California"],
+        ["CO", "Colorado"],
+        ["CT", "Connecticut"],
+        ["DE", "Delaware"],
+        ["DC", "District of Columbia"],
+        ["FL", "Florida"],
+        ["GA", "Georgia"],
+        ["GU", "Guam"],
+        ["HI", "Hawaii"],
+        ["ID", "Idaho"],
+        ["IL", "Illinois"],
+        ["IN", "Indiana"],
+        ["IA", "Iowa"],
+        ["KS", "Kansas"],
+        ["KY", "Kentucky"],
+        ["LA", "Louisiana"],
+        ["ME", "Maine"],
+        ["MD", "Maryland"],
+        ["MA", "Massachusetts"],
+        ["MI", "Michigan"],
+        ["MN", "Minnesota"],
+        ["MS", "Mississippi"],
+        ["MO", "Missouri"],
+        ["MT", "Montana"],
+        ["NE", "Nebraska"],
+        ["NV", "Nevada"],
+        ["NH", "New Hampshire"],
+        ["NJ", "New Jersey"],
+        ["NM", "New Mexico"],
+        ["NY", "New York"],
+        ["NC", "North Carolina"],
+        ["ND", "North Dakota"],
+        ["MP", "Northern Mariana Islands"],
+        ["OH", "Ohio"],
+        ["OK", "Oklahoma"],
+        ["OR", "Oregon"],
+        ["PA", "Pennsylvania"],
+        ["PR", "Puerto Rico"],
+        ["RI", "Rhode Island"],
+        ["SC", "South Carolina"],
+        ["SD", "South Dakota"],
+        ["TN", "Tennessee"],
+        ["TX", "Texas"],
+        ["UT", "Utah"],
+        ["VT", "Vermont"],
+        ["VA", "Virginia"],
+        ["VI", "US Virgin Islands"],
+        ["WA", "Washington"],
+        ["WV", "West Virginia"],
+        ["WI", "Wisconsin"],
+        ["WY", "Wyoming"]
+        ]
+        inputHtml = `<select class="form-select state-dropdown" name="${fieldName}" id="${fieldId}" ${requiredAttr}>`
+        for (let state of STATE_CHOICES) {
+          inputHtml += `<option value="${state[0]}">${state[1]}</option>`
+        }
+        inputHtml += "</select>"
+        break;
+
       case "party_type_dropdown":
         // Create a dropdown for party types that will be populated via API
         inputHtml = `
@@ -929,15 +986,10 @@ class DynamicFormSections {
         }
 
         // Build API URL with parameters
-        const url = new URL(apiEndpoint, window.location.origin);
-        url.searchParams.append("court", court);
-        url.searchParams.append("case_type", caseType);
+        const result = await apiUtils.get(apiEndpoint, {court, "case_type": caseType, "jurisdiction": this.jurisdiction});
 
-        const response = await fetch(url);
-        const result = await response.json();
-
-        if (result.success && result.data && result.data.party_types) {
-          const partyTypes = result.data.party_types;
+        if (result.success && result.data) {
+          const partyTypes = result.data;
 
           // Clear existing options except the first one
           dropdown.innerHTML = '<option value="">Select Party Type</option>';

--- a/efile_app/efile/static/js/form-validation.js
+++ b/efile_app/efile/static/js/form-validation.js
@@ -656,10 +656,9 @@ class FormValidation {
             console.warn(
               "dynamicFormSections not available when setting case_type"
             );
-            // Try to trigger manually
-            const changeEvent = new Event("change", { bubbles: true });
-            dropdown.dispatchEvent(changeEvent);
           }
+          const changeEvent = new Event("change", { bubbles: true });
+          dropdown.dispatchEvent(changeEvent);
         }, 300); // Give time for dropdown to settle
       }
     } else {

--- a/efile_app/efile/static/js/review.js
+++ b/efile_app/efile/static/js/review.js
@@ -629,6 +629,29 @@ const FilingHandler = {
       });
     }
 
+    let other_parties = [];
+
+    if (caseData.other_first_name && caseData.other_party_type) {
+      other_parties.push({
+        party_type: caseData.other_party_type,
+        name: {
+          first: caseData.other_first_name,
+          last: caseData.other_last_name
+        },
+        address: {
+          address: caseData.other_address_line_1,
+          unit: caseData.other_address_line_2,
+          city: caseData.other_address_city,
+          state: caseData.other_address_state,
+          zip: caseData.other_address_zip,
+          country: "US"
+        },
+        email: caseData.other_email,
+        phone_number: caseData.other_phone_number,
+        is_new: true,
+      });
+    }
+
     const efilingData = {
       efile_case_category: caseData.case_category,
       efile_case_type: caseData.case_type,
@@ -636,7 +659,7 @@ const FilingHandler = {
       previous_case_id: caseData?.previous_case_id,
       docket_number: caseData?.docket_number,
       users,
-      other_parties: [],
+      other_parties,
       user_started_case: !caseData?.previous_case_id,
       al_court_bundle: [],
       cross_references: "",

--- a/efile_app/efile/templates/efile/expert_form.html
+++ b/efile_app/efile/templates/efile/expert_form.html
@@ -105,7 +105,89 @@
               </div>
             </div>
           </div>
-        </div>
+
+          <div class="row mb-3">
+            <div class="col-md-6" id="party-type-section">
+              <label for="party_type" class="form-label">Party Type<span class="required">*</span></label>
+              <small class="form-text text-muted mb-2 d-block">
+                This is your party type.
+              </small>
+              <select class="form-select dropdown-field" id="party_type" name="party_type" data-level="2" required
+                >
+                <option value="">Select party type</option>
+              </select>
+              <div class="loading-spinner" id="loading-2" style="display: none">
+                <i class="fas fa-spinner fa-spin"></i> Loading party types...
+              </div>
+            </div>
+          </div>
+
+          <!--div id="other-party-section">
+          <h3 class="subsection-header">The Other Side Of The Case</h3>
+          <div class="row mb-3">
+            <div class="col-md-6">
+              <small class="form-text text-muted mb-2 d-block">
+                This type of case has someone on the other side. Enter their information here.
+              </small>
+            </div>
+          </div>
+          <div class="mb-3">
+              <select class="form-select dropdown-field" id="other_party1_party_type" name="party_type" data-level="1" required
+                disabled>
+                <option value="">Select party type</option>
+              </select>
+              <div class="loading-spinner" id="loading-1" style="display: none">
+                <i class="fas fa-spinner fa-spin"></i> Loading party types...
+              </div>
+          </div>
+          <div class="row mb-2">
+            <div class="col-md-6">
+              <label class="form-label"for="other_party1_familiar_name_id">Their First or Given Name:</label>
+              <input class="form-control" type="text" maxlength="255" autocomplete="given-name" id="other_party1_familiar_name_id" name="other_party1_familiar_name" />
+            </div>
+            <div class="col-md-6">
+              <label class="form-label" for="other_party1_middle_name_id">Their Middle Name:</label>
+              <input class="form-control" type="text" maxlength="255" autocomplete="additional-name" id="other_party1_middle_name_id" name="other_party1_middle_name" />
+            </div>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="other_party1_family_name_id">Their Last or Family Name:</label>
+            <input class="form-control" type="text" malength="255" autocomplete="family-name" name="other_party1_family_name" />
+          </div>
+          <h4 class="section-title">Their Physical Address:</h4>
+          <div class="mb-3">
+            <label class="form-label" for="other_party1_address_first_line_id">Street Address:</label>
+            <input class="form-control" type="text" id="other_part1_address_first_line_id" name="other_party1_address_first_line" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="other_party1_address_second_line_id">Street Address 2:</label>
+            <input class="form-control" type="text" id="other_party1_address_second_line_id" name="other_party1_address_second_line" />
+          </div>
+          <div class="row">
+            <div class="col-md-5">
+              <label class="form-label" for="other_party1_address_city_id">City:</label>
+              <input class="form-control" type="text" id="other_party1_address_city_id" name="other_party1_address_city" />
+            </div>
+            <div class="col-md-4">
+              <label class="form-label" for="other_party1_address_state_id">State:</label>
+              <input class="form-control" type="text" id="other_party_address_state_id" name="other_party1_address_state" />
+            </div>
+            <div class="col-md-3">
+              <label class="form-label" for="other_party1_address_zip_id">Zip code:</label>
+              <input class="form-control" maxlength="10" type="text" id="other_party1_address_zip_id" name="other_party1_address_zip" />
+            </div>
+          </div>
+          <h4 class="section-title">Their Contact Information</h4>
+          <div class="mb-3">
+            <label class="form-label" for="other_party1_email_id">Email:</label>
+            <input class="form-control" type="email" id="other_party1_email_id" name="other_party1_email"></input>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="other_party1_email_id">Phone:</label>
+            <input class="form-control" type="tel" name="other_party1_phone"></input>
+          </div>
+          </div>
+          </div-->
 
         <!-- Case Information Section -->
         <div id="case-search-subsection" hidden>
@@ -207,6 +289,71 @@
         continueBtn.disabled = true;
       });
     }
+
+    /*
+    function toggleSelfPartyType(show) {
+      if (show) {
+        document.getElementById("party-type-section").removeAttribute("hidden");
+      } else {
+        document.getElementById("party-type-section").setAttribute("hidden", true);
+      }
+    }
+
+    function toggleOtherParties(show) {
+      if (show) {
+        document.getElementById("other-party-section").removeAttribute("hidden");
+      } else {
+        document.getElementById("other-party-section").setAttribute("hidden", true);
+      }
+    }
+
+    document.getElementById("case_type").addEventListener("change", async (e) => {
+      if (e.target.value) {
+        const params = {
+          jurisdiction: apiUtils.getCurrentJurisdiction(),
+          court: caseData.court,
+          case_type: caseData.case_type,
+          existing_case: caseData.existing_case || 'no'
+        };
+
+        const result = await apiUtils.getPartyTypes(params);
+    
+        if (result?.success) {
+          console.log('Party types received:', result.party_types);
+          console.log('Selected party type:', result.selected_party_type);
+          if (result.party_types.length > 1) {
+            toggleSelfPartyType(true);
+            toggleOtherParties(true);
+          } else {
+            toggleSelfPartyType(false);
+            toggleOtherParties(false);
+          }
+        } else {
+          console.error('Party type fetch failed:', result?.error);
+        }
+      } else {
+        toggleSelfPartyType(false);
+        toggleOtherParties(false);
+      }
+    });
+
+    document.getElementById("party_type").addEventListener("change", async (e) => {
+      if (e.target.value) {
+        let partyTypes = document.getElementById("party_type").children;
+        let otherPartyType = document.getElementById("other_party1_party_type");
+        for (let partyType of partyTypes) {
+          if (partyType.value && partyType.value !== "" && partyType.value !== e.target.value) {
+            let newType = document.createElement("option");
+            newType.value=partyType.value;
+            newType.name = partyType.name;
+            newType.textContent = partyType.textContent;
+            otherPartyType.appendChild(newType);
+          }
+        }
+        otherPartyType.disabled = false;
+      }
+    });
+    */
 
     // Extract case data from Django template and make it available globally
     const caseDataElement = document.getElementById("case-data");

--- a/efile_app/efile/utils/config_loader.py
+++ b/efile_app/efile/utils/config_loader.py
@@ -133,17 +133,17 @@ class JurisdictionConfigLoader:
     def get_short_jurisdiction_config(self, jurisdiction):
         return self.load_jurisdiction_config(jurisdiction)["jurisdiction"]
 
-    def _find_with_keywords(self, key, entries):
+    def _find_with_keywords(self, key, cases):
         """
         Given a dictionary with keys and keywords (as a list in the key's value),
         return the value that the key matches (for the dict or the keyword).
         """
-        if key in entries:
-            return entries[key]
+        if key in cases:
+            return cases[key]
 
-        for value in entries.values():
-            if "keywords" in value and key in value["keywords"]:
-                return value
+        for case in cases.values():
+            if "keywords" in case and key in case["keywords"]:
+                return case
 
         return None
 
@@ -169,8 +169,12 @@ class JurisdictionConfigLoader:
             case_config = self._find_with_keywords(case_type, case_types)
             if case_config:
                 break
+
         if case_config is None:
-            return None
+            if "defaults" in jurisdiction:
+                return jurisdiction["defaults"]
+            else:
+                return None
 
         case_config = deepcopy(case_config)
 


### PR DESCRIPTION
If a case every has more than 1 required party type available, shows
the party type select for the current user and information for the other parties.

Actually integrated with the existing dynamic form sections and
jconfig stuff. They had horrible defaults and I had to understand the full stack,
but it is useful code now.

Fixes #27.