### PR TITLE
Remove hardcoded dev EFSP Proxy URL

### DIFF
--- a/efile_app/efile/static/js/review.js
+++ b/efile_app/efile/static/js/review.js
@@ -441,7 +441,7 @@ const PaymentHandler = {
     
     const jurisdiction = authData.state || apiUtils.getCurrentJurisdiction();
     // TODO: we should revisit this hardcoded value in the future too
-    form.action = `http://localhost:9100/jurisdictions/${encodeURIComponent(jurisdiction)}/payments/new-toga-account`;
+    form.action = Utils.parseJSON('new-toga-url');
 
     let dateStr = new Date().toDateString();
     const fields = [

--- a/efile_app/efile/templates/efile/review.html
+++ b/efile_app/efile/templates/efile/review.html
@@ -348,6 +348,7 @@
 
     <!-- Django template data for JavaScript -->
     {{ case_data|json_script:"case-data" }}
+    {{ new_toga_url|json_script:"new-toga-url" }}
     {{ friendly_names|json_script:"friendly-names" }}
 
     <!-- Review page JavaScript -->

--- a/efile_app/efile/views/review.py
+++ b/efile_app/efile/views/review.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib import messages
 from django.shortcuts import redirect, render
 
@@ -91,7 +92,10 @@ def case_review(request, jurisdiction):
             "items": [{"label": "Selected Services", "value": ", ".join(optional_services)}],
         }
 
+    new_toga_url = f"{settings.EFSP_URL}/jurisdictions/{jurisdiction}/payments/new-toga-account"
+
     context = {
+        "new_toga_url": new_toga_url,
         "case_data": case_data,
         "review_sections": review_sections,
         "friendly_names": {


### PR DESCRIPTION
Embeds it in the review page when serving instead. Not sure of a better way at the moment.