### PR TITLE
Add landing page text to 'options' page

### DIFF
--- a/efile_app/efile/settings_base.py
+++ b/efile_app/efile/settings_base.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "efile",
+    "efile.templatetags.md_to_html",
 ]
 
 MIDDLEWARE = [

--- a/efile_app/efile/static/config/states/massachusetts.yaml
+++ b/efile_app/efile/static/config/states/massachusetts.yaml
@@ -13,6 +13,12 @@ jurisdiction:
   help_url: "https://www.mass.gov/orgs/massachusetts-court-system"
   help_number: "711"
   copyedit:
+    landing_text: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed fringilla enim ut nibh aliquam venenatis. Vivamus lacinia risus vitae massa aliquet, id hendrerit mi tincidunt. Vestibulum aliquet sapien ut velit laoreet, in blandit lectus congue. Ut at massa in eros sodales porta id sit amet urna. Proin suscipit venenatis justo sit amet condimentum. Donec volutpat sem nec facilisis tristique. Sed elementum ante nisi, id lacinia eros pellentesque in. Curabitur quis ante ut nunc pharetra tincidunt. Maecenas ornare augue eu diam condimentum congue. Pellentesque ac lorem quis magna rutrum euismod pharetra ac massa. Nulla felis erat, consectetur eu lacus ac, scelerisque rhoncus diam. Sed gravida ex ut maximus dapibus. Sed eu hendrerit est. Maecenas in porta lacus.
+    post_action_text: |
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed fringilla enim ut nibh aliquam venenatis. Vivamus lacinia risus vitae massa aliquet, id hendrerit mi tincidunt. Vestibulum aliquet sapien ut velit laoreet, in blandit lectus congue. Ut at massa in eros sodales porta id sit amet urna. Proin suscipit venenatis justo sit amet condimentum. Donec volutpat sem nec facilisis tristique. Sed elementum ante nisi, id lacinia eros pellentesque in. Curabitur quis ante ut nunc pharetra tincidunt. Maecenas ornare augue eu diam condimentum congue. Pellentesque ac lorem quis magna rutrum euismod pharetra ac massa. Nulla felis erat, consectetur eu lacus ac, scelerisque rhoncus diam. Sed gravida ex ut maximus dapibus. Sed eu hendrerit est. Maecenas in porta lacus.
+
+      Nulla at blandit risus, vel vehicula magna. Quisque ullamcorper lorem eget erat dignissim, id posuere ante lacinia. Quisque luctus vitae velit sed vulputate. Ut gravida ipsum in consectetur tincidunt. Quisque ac purus nunc. Sed sit amet accumsan dolor, in ullamcorper orci. Donec maximus imperdiet libero. Pellentesque vel feugiat magna, congue fermentum mi. Mauris vel molestie ex. Sed quis augue semper, tempus est vitae, porta felis.
     filing_statuses: |
       These are filings that you have already sent to the courts, either through this website or elsewhere.
 

--- a/efile_app/efile/templates/efile/choose_jurisdiction.html
+++ b/efile_app/efile/templates/efile/choose_jurisdiction.html
@@ -35,7 +35,7 @@
                         align-items:center">
                 {% for value in jurisdiction_details %}
                     <div class="option-card" style="position:relative">
-                        <a href="{% url 'efile_login' jurisdiction=value.jurisdiction.code %}"
+                        <a href="{% url 'efile_options' jurisdiction=value.jurisdiction.code %}"
                            style="position:absolute;
                                   width:100%;
                                   height:100%;

--- a/efile_app/efile/templates/efile/options.html
+++ b/efile_app/efile/templates/efile/options.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load i18n %}
+{% load md_to_html %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -32,37 +33,58 @@
             <h1>{% translate "File Forms and Documents with the Court" %}</h1>
             <div class="row justify-content-center">
                 <div class="col-xl-7">
-                    <div id="existing-placeholder"></div>
-                    <div class="option-card">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="option-icon">
-                                <i class="fas fa-university"></i>
+                    <p>{{ config.jurisdiction.copyedit.landing_text | md_to_html }}</p>
+                    {% if not is_logged_in %}
+                        <div class="option-card">
+                            <div class="d-flex align-items-center mb-3">
+                                <div class="option-icon">
+                                    <i class="fas fa-folder-open"></i>
+                                </div>
+                                <div class="option-content">
+                                    <h2>{% translate "Start making your filing" %}</h2>
+                                    <p>{% translate "Sign in or create an account and start making your filing." %}</p>
+                                </div>
                             </div>
-                            <div class="option-content">
-                                <h2>{% translate "Start a new filing" %}</h2>
-                                <p>{% translate "Begin a new case or file a response." %}</p>
-                            </div>
-                        </div>
-                        <div class="button-group">
-                            <button class="btn btn-primary" tabindex="0" onclick="goToExpertForm('new')">{% translate "Begin" %}</button>
-                        </div>
-                    </div>
-                    <div class="option-card">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="option-icon">
-                                <i class="fas fa-folder-open"></i>
-                            </div>
-                            <div class="option-content">
-                                <h2>{% translate "View past filings" %}</h2>
-                                <p>{% translate "See if a filing you have made was accepted or rejected." %}</p>
+                            <div class="button-group">
+                                <a href="{% url 'efile_login' jurisdiction %}"
+                                   class="btn btn-primary"
+                                   tabindex="0">{% translate "Sign in" %}</a>
                             </div>
                         </div>
-                        <div class="button-group">
-                            <a href="{% url 'filing_statuses' jurisdiction %}"
-                               class="btn btn-primary"
-                               tabindex="0">{% translate "View" %}</a>
+                    {% else %}
+                        <div id="existing-placeholder"></div>
+                        <div class="option-card">
+                            <div class="d-flex align-items-center mb-3">
+                                <div class="option-icon">
+                                    <i class="fas fa-university"></i>
+                                </div>
+                                <div class="option-content">
+                                    <h2>{% translate "Start a new filing" %}</h2>
+                                    <p>{% translate "Begin a new case or file a response." %}</p>
+                                </div>
+                            </div>
+                            <div class="button-group">
+                                <button class="btn btn-primary" tabindex="0" onclick="goToExpertForm('new')">{% translate "Begin" %}</button>
+                            </div>
                         </div>
-                    </div>
+                        <div class="option-card">
+                            <div class="d-flex align-items-center mb-3">
+                                <div class="option-icon">
+                                    <i class="fas fa-folder-open"></i>
+                                </div>
+                                <div class="option-content">
+                                    <h2>{% translate "View past filings" %}</h2>
+                                    <p>{% translate "See if a filing you have made was accepted or rejected." %}</p>
+                                </div>
+                            </div>
+                            <div class="button-group">
+                                <a href="{% url 'filing_statuses' jurisdiction %}"
+                                   class="btn btn-primary"
+                                   tabindex="0">{% translate "View" %}</a>
+                            </div>
+                        </div>
+                    {% endif %}
+                    <p>{{ config.jurisdiction.copyedit.post_action_text | md_to_html }}</p>
                 </div>
             </div>
         </div>

--- a/efile_app/efile/templatetags/md_to_html.py
+++ b/efile_app/efile/templatetags/md_to_html.py
@@ -1,0 +1,12 @@
+import markdown
+from django import template
+from django.utils.safestring import mark_safe
+
+
+def md_to_html(value):  # Only one argument.
+    """Converts a string into all lowercase"""
+    return mark_safe(markdown.markdown(value))
+
+
+register = template.Library()
+register.filter("md_to_html", md_to_html)

--- a/efile_app/efile/views/options.py
+++ b/efile_app/efile/views/options.py
@@ -1,18 +1,19 @@
-from django.shortcuts import redirect, render
+from django.shortcuts import render
 
 from ..utils.case_data_utils import get_case_data
 
 
 def efile_options(request, jurisdiction):
     """Options view that displays saved case data and provides next steps."""
-    if not request.user.is_authenticated:
-        return redirect("efile_login", jurisdiction=jurisdiction)
-
     # Get case data from session
-    case_data = get_case_data(request)
+    if request.user.is_authenticated:
+        case_data = get_case_data(request)
+    else:
+        case_data = {}
 
     # Pass case data to template for display
     context = {
+        "is_logged_in": request.user.is_authenticated,
         "case_data": case_data,
         "has_case_data": bool(case_data),
     }

--- a/efile_app/pyproject.toml
+++ b/efile_app/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "openai>=2.14.0",
     "markitdown>=0.1.4",
     "djlint>=1.36.4",
+    "markdown>=3.10.2",
+    "markdownify>=1.2.2",
 ]
 
 [build-system]

--- a/efile_app/uv.lock
+++ b/efile_app/uv.lock
@@ -435,6 +435,8 @@ dependencies = [
     { name = "django" },
     { name = "djlint" },
     { name = "gunicorn" },
+    { name = "markdown" },
+    { name = "markdownify" },
     { name = "markitdown" },
     { name = "openai" },
     { name = "psycopg", extra = ["binary"] },
@@ -466,6 +468,8 @@ requires-dist = [
     { name = "django", specifier = "==5.2.5" },
     { name = "djlint", specifier = ">=1.36.4" },
     { name = "gunicorn", specifier = ">=22.0" },
+    { name = "markdown", specifier = ">=3.10.2" },
+    { name = "markdownify", specifier = ">=1.2.2" },
     { name = "markitdown", specifier = ">=0.1.4" },
     { name = "openai", specifier = ">=2.14.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
@@ -745,6 +749,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/25/8f/132b0d7cd51c02c39fd52658a5896276c30c8cc2fd453270b19db8c40f7e/magika-0.6.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:86901e64b05dde5faff408c9b8245495b2e1fd4c226e3393d3d2a3fee65c504b", size = 13358841, upload-time = "2025-10-30T15:22:27.413Z" },
     { url = "https://files.pythonhosted.org/packages/c4/03/5ed859be502903a68b7b393b17ae0283bf34195cfcca79ce2dc25b9290e7/magika-0.6.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3d9661eedbdf445ac9567e97e7ceefb93545d77a6a32858139ea966b5806fb64", size = 15367335, upload-time = "2025-10-30T15:22:29.907Z" },
     { url = "https://files.pythonhosted.org/packages/7b/9e/f8ee7d644affa3b80efdd623a3d75865c8f058f3950cb87fb0c48e3559bc/magika-0.6.3-py3-none-win_amd64.whl", hash = "sha256:e57f75674447b20cab4db928ae58ab264d7d8582b55183a0b876711c2b2787f3", size = 12692831, upload-time = "2025-10-30T15:22:32.063Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I think it's better than having a separate landing page.

Can still show all of the information we want on that main page.

Fix #78, for the moment. Will need an actual pass to put in the jurisdiction text.