### PR TITLE
Avoid duplicate CI runs on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 env:


### PR DESCRIPTION
## Summary
- Restrict the `push` trigger for the CI workflow to `main`
- Keep `pull_request` checks unchanged for PR validation

## Testing
- Not run; workflow-only change

Fixes #110